### PR TITLE
Lade till grundattributet istället för det browser-prefixade

### DIFF
--- a/gym.css
+++ b/gym.css
@@ -50,7 +50,10 @@ li.dropdown {
 .dropdown:hover .dropdown-content {
     display: block;
 }
-.main{ -webkit-columns: 200px 3; margin:inherit;}
+.main{ 
+    columns: 200px 3;
+    margin:inherit;
+}
 .title{text-align:center;}
 .form{
 height: 600px;


### PR DESCRIPTION
När något börjar med t ex -webkit- så betyder det att det är ett
webbläsar-prefix.

Webkit är den webbrenderare chrome använder. tror mozilla använder -moz-
och microsoft använder -ms-.

När ett nytt sätt att implementera något introduceras så gör det ofta
det av de individuella webbläsarna under sina egna prefix. När de kommer
överrens om hur ett förslag ska implementeras så implementeras det utan
webbläsar-prefix och enligt samma standard i alla webbläsare.

Försök lösa saker och ting utan webbläsar-prefix först. sedan kan ni gå
in och göra anpassningar till olika webbläsare om ni har det som krav :)

Här är iaf en fix på er första bugg :)